### PR TITLE
Use zipfile37 instead of zipfile.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "zlib"]
 	path = zlib
 	url = https://github.com/madler/zlib.git
+[submodule "zipfile37"]
+	path = zipfile37
+	url = https://github.com/markus1978/zipfile37.git

--- a/zipfile_deflate64/__init__.py
+++ b/zipfile_deflate64/__init__.py
@@ -4,7 +4,7 @@
 from . import _zipfile  # noqa: F401
 
 # Re-export everything, so this can be used in place of zipfile
-from zipfile import *  # noqa: F401, F403
+from zipfile37 import *  # noqa: F401, F403
 
 # ZIP_DEFLATED64 is not a part of zipfile.__all__
-from zipfile import ZIP_DEFLATED64  # type: ignore[attr-defined] # noqa: F401
+from zipfile37 import ZIP_DEFLATED64  # type: ignore[attr-defined] # noqa: F401

--- a/zipfile_deflate64/_zipfile.py
+++ b/zipfile_deflate64/_zipfile.py
@@ -1,4 +1,4 @@
-import zipfile
+import zipfile37 as zipfile
 
 from . import deflate64
 from ._patcher import patch


### PR DESCRIPTION
In Python 3.6, the zipfile module has the following issues:

- Cannot decompress zip files with compression type 9 (deflate64)
- Cannot unzip files with disks==0 (see [bpo-22102](https://bugs.python.org/issue22102))

These issues are resolved independently by the following modules:

- @brianhelba's [zipfile-deflate64](https://github.com/brianhelba/zipfile-deflate64) module (parent of this repo)
- @markus1978's [zipfile37](https://github.com/markus1978/zipfile37) module. This is a backport of the zipfile module from Python 3.7 (which contains a [patch for bpo-22101](https://github.com/python/cpython/commit/0eb69990c85b6c82c677d5a43e3df28836ae845e)) into Python 3.6.

This PR combines the above solutions by pulling the zipfile37 module into the zipfile-deflate64 implementation.  Now this version of zipfile-deflate64 can handle both scenarios in Python versions 3.6 and earlier.